### PR TITLE
FIX: A topic ID that has been dismissed should return successful empty results

### DIFF
--- a/app/controllers/discourse_onboarding_banner/discourse_onboarding_banner_controller.rb
+++ b/app/controllers/discourse_onboarding_banner/discourse_onboarding_banner_controller.rb
@@ -7,7 +7,9 @@ module DiscourseOnboardingBanner
     before_action :ensure_logged_in
 
     def index
-      raise Discourse::NotFound unless current_user.show_onboarding_banner
+      unless current_user.show_onboarding_banner
+        return render json: success_json
+      end
 
       topic = Topic.find(SiteSetting.discourse_onboarding_banner_topic_id)
 
@@ -22,7 +24,7 @@ module DiscourseOnboardingBanner
       current_user.custom_fields['onboarding_banner_dismissed_topic_id'] = topic_id
       current_user.save_custom_fields
 
-      head :ok
+      render json: success_json
     end
   end
 end

--- a/assets/javascripts/discourse/templates/components/onboarding-banner.hbs
+++ b/assets/javascripts/discourse/templates/components/onboarding-banner.hbs
@@ -1,4 +1,4 @@
-{{#unless maxExpired}}
+{{#unless shouldHideBanner}}
   <div class="onboarding-banner-content">
     {{html-safe cooked}}
     {{d-button

--- a/spec/requests/discourse_onboarding_banner_controller_spec.rb
+++ b/spec/requests/discourse_onboarding_banner_controller_spec.rb
@@ -46,7 +46,9 @@ describe DiscourseOnboardingBanner::DiscourseOnboardingBannerController do
       context 'without setting a topic_id' do
         it 'returns error when getting content' do
           get '/discourse-onboarding-banner/content.json'
-          expect(response.status).to eq(404)
+
+          json = response.parsed_body
+          expect(json['topic_id']).to eq(nil)
         end
 
         it 'returns error dismissing content' do
@@ -56,7 +58,8 @@ describe DiscourseOnboardingBanner::DiscourseOnboardingBannerController do
       end
 
       context 'after setting a topic_id' do
-        fab!(:topic) { Fabricate(:topic) }
+        fab!(:lounge) { Fabricate(:category, name: I18n.t("vip_category_name")) }
+        fab!(:topic) { Fabricate(:topic, category: lounge) }
         fab!(:post) { Fabricate(:post, topic: topic, raw: 'My onboarding content') }
 
         before do
@@ -79,23 +82,29 @@ describe DiscourseOnboardingBanner::DiscourseOnboardingBannerController do
           expect(user.custom_fields).to eq({ 'onboarding_banner_dismissed_topic_id' => topic.id.to_s })
 
           get '/discourse-onboarding-banner/content.json'
-          expect(response.status).to eq(404)
+
+          json = response.parsed_body
+          expect(json['topic_id']).to eq(nil)
         end
       end
 
       context 'setting an invalid topic_id' do
-        it 'returns an error if topic is nil' do
+        it 'returns an empty topic_id if topic_id is nil' do
           SiteSetting.discourse_onboarding_banner_topic_id = nil
 
           get '/discourse-onboarding-banner/content.json'
-          expect(response.status).to eq(404)
+
+          json = response.parsed_body
+          expect(json['topic_id']).to eq(nil)
         end
 
-        it 'returns an error if topic does not exist' do
+        it 'returns an empty topic_id if topic_id is invalid' do
           SiteSetting.discourse_onboarding_banner_topic_id = 99_999_999
 
           get '/discourse-onboarding-banner/content.json'
-          expect(response.status).to eq(404)
+
+          json = response.parsed_body
+          expect(json['topic_id']).to eq(nil)
         end
       end
     end


### PR DESCRIPTION
Keep a localStorage object after dismissal, but remove the cooked post. Only display the content if the cooked post is present.